### PR TITLE
fix/minsdkversion bumped to avoid dex error

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -49,7 +49,8 @@ android {
         applicationId "com.dareyou.dareyou"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        // minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
The build seems to give error for single dex files due to being a debug build with min sdk support to 16.
bumping it since there is no quick way to build via flutter command line flag and pass minsdk version etc.